### PR TITLE
fix: use neutral timezone to prevent date shifts

### DIFF
--- a/angular-hub/src/app/app.config.ts
+++ b/angular-hub/src/app/app.config.ts
@@ -1,4 +1,5 @@
 import {ApplicationConfig} from '@angular/core';
+import {DATE_PIPE_DEFAULT_OPTIONS} from '@angular/common';
 import {provideHttpClient, withFetch} from '@angular/common/http';
 import {provideClientHydration} from '@angular/platform-browser';
 import {provideFileRouter} from '@analogjs/router';
@@ -7,6 +8,7 @@ import {provideAnimations} from "@angular/platform-browser/animations";
 
 export const appConfig: ApplicationConfig = {
     providers: [
+        { provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: { timezone: '+0000' } },
         provideFileRouter(),
         provideClientHydration(),
         provideHttpClient(withFetch()),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular-sanctuary/angular-hub/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #28 

## What is the new behavior?

Timezones are ignored since local datetimes are used for events.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

I considered adding timezones to the content files instead, but this would create confusion when compared to event materials since they always use local time, so shifting doesn't make sense in this case.