### PR TITLE
fix: Filtering by past events should not include events happening today

### DIFF
--- a/angular-hub/src/app/pages/events/index.page.ts
+++ b/angular-hub/src/app/pages/events/index.page.ts
@@ -83,7 +83,7 @@ export default class EvenementsComponent {
       new Date(b.attributes.date).getTime()
   );
   pastEvents = this.evenements.filter(
-    (event) => new Date(event.attributes.date).getTime() < Date.now()
+    (event) => new Date(event.attributes.date).getTime() < this.today().getTime()
   );
   upcomingEvents = this.evenements.filter(
     (event) => new Date(event.attributes.date) >= this.today()


### PR DESCRIPTION
The event dates stored so far do not have a time aspect, so they will always be less than `Date.now()` when the "date" part is the same as today.

<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->

<!-- Are you adding a conference event? Mind listing it on https://github.com/scraly/developers-conferences-agenda too for a broader audience! -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Filtering by "past" events includes events happening today.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #56 

## What is the new behavior?
Filtering by "past" events excludes events happening today.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
