### PR TITLE
fix(search): change outline rule to hide outline on Safari

### DIFF
--- a/angular-hub/src/app/components/search.component.ts
+++ b/angular-hub/src/app/components/search.component.ts
@@ -31,7 +31,7 @@ import { MatIconModule } from '@angular/material/icon';
     >
       <mat-icon svgIcon="search"></mat-icon>
       <input
-        class="flex-1 outline-0 bg-transparent"
+        class="flex-1 outline-none bg-transparent"
         type="text"
         aria-label="Search"
         [(ngModel)]="searchTerm"


### PR DESCRIPTION
<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->

<!-- Are you adding a conference event? Mind listing it on https://github.com/scraly/developers-conferences-agenda too for a broader audience! -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The native outline is visible on input on Safari (delegated to the fieldset)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

The outline is now longer visible.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
