### PR TITLE
fix: Reorder past events in descending order

### DIFF
--- a/angular-hub/src/app/pages/events/index.page.ts
+++ b/angular-hub/src/app/pages/events/index.page.ts
@@ -82,14 +82,9 @@ export default class EvenementsComponent {
 
   evenements = injectContentFiles<Event>(({ filename }) =>
     filename.startsWith('/src/content/events/')
-  ).sort(
-    (a, b) =>
-      new Date(a.attributes.date).getTime() -
-      new Date(b.attributes.date).getTime()
   );
   pastEvents = this.evenements.filter(
-    (event) =>
-      new Date(event.attributes.date).getTime() < this.today().getTime()
+    (event) => new Date(event.attributes.date) < this.today()
   );
   upcomingEvents = this.evenements.filter(
     (event) => new Date(event.attributes.date) >= this.today()
@@ -101,14 +96,23 @@ export default class EvenementsComponent {
     ),
     map(({ search: searchTerm = '', state }) => {
       if (state === 'past') {
-        return this.pastEvents.filter((event) =>
-          this.filterPredicate(event.attributes, searchTerm)
-        );
-      } else {
-        return this.upcomingEvents.filter((event) =>
-          this.filterPredicate(event.attributes, searchTerm)
-        );
+        return this.pastEvents
+          .filter((event) => this.filterPredicate(event.attributes, searchTerm))
+          .sort((a, b) => {
+            return (
+              new Date(b.attributes.date).getTime() -
+              new Date(a.attributes.date).getTime()
+            );
+          });
       }
+      return this.upcomingEvents
+        .filter((event) => this.filterPredicate(event.attributes, searchTerm))
+        .sort((a, b) => {
+          return (
+            new Date(a.attributes.date).getTime() -
+            new Date(b.attributes.date).getTime()
+          );
+        });
     })
   );
 

--- a/angular-hub/src/app/pages/events/index.page.ts
+++ b/angular-hub/src/app/pages/events/index.page.ts
@@ -99,19 +99,24 @@ export default class EvenementsComponent {
         return this.pastEvents
           .filter((event) => this.filterPredicate(event.attributes, searchTerm))
           .sort((a, b) => {
-            return (
+            const dayDiff =
               new Date(b.attributes.date).getTime() -
-              new Date(a.attributes.date).getTime()
-            );
+              new Date(a.attributes.date).getTime();
+            return dayDiff === 0
+              ? a.attributes.title.localeCompare(b.attributes.title)
+              : dayDiff;
           });
       }
+
       return this.upcomingEvents
         .filter((event) => this.filterPredicate(event.attributes, searchTerm))
         .sort((a, b) => {
-          return (
+          const dayDiff =
             new Date(a.attributes.date).getTime() -
-            new Date(b.attributes.date).getTime()
-          );
+            new Date(b.attributes.date).getTime();
+          return dayDiff === 0
+            ? a.attributes.title.localeCompare(b.attributes.title)
+            : dayDiff;
         });
     })
   );


### PR DESCRIPTION
<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->

<!-- Are you adding a conference event? Mind listing it on https://github.com/scraly/developers-conferences-agenda too for a broader audience! -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Past events (under Agenda) show the oldest event first instead of the most recent event.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #86 

## What is the new behavior?
Past events are sorted in reverse chronological order. Events occurring on the same date are sorted alphabetically by title.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Fixes #86