### PR TITLE
feat: new control flow syntax

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,9 +1,7 @@
 {
   "projectName": "angular-hub",
   "projectOwner": "angular-sanctuary",
-  "files": [
-    "README.md"
-  ],
+  "files": ["README.md"],
   "commitType": "docs",
   "commitConvention": "angular",
   "contributorsPerLine": 7,
@@ -13,114 +11,84 @@
       "name": "Patrick Murimi",
       "avatar_url": "https://avatars.githubusercontent.com/u/89421020?v=4",
       "profile": "https://linkfree.io/grand-rick001",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "rlmestre",
       "name": "Rafael Mestre",
       "avatar_url": "https://avatars.githubusercontent.com/u/277805?v=4",
       "profile": "https://github.com/rlmestre",
-      "contributions": [
-        "bug",
-        "code"
-      ]
+      "contributions": ["bug", "code"]
     },
     {
       "login": "DominikPieper",
       "name": "Dominik Pieper",
       "avatar_url": "https://avatars.githubusercontent.com/u/77470?v=4",
       "profile": "http://nxext.dev",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "giovnzcr",
       "name": "giovnzcr",
       "avatar_url": "https://avatars.githubusercontent.com/u/11030212?v=4",
       "profile": "https://github.com/giovnzcr",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "Dyqmin",
       "name": "Dominik Donoch",
       "avatar_url": "https://avatars.githubusercontent.com/u/23712053?v=4",
       "profile": "https://github.com/Dyqmin",
-      "contributions": [
-        "bug",
-        "code"
-      ]
+      "contributions": ["bug", "code"]
     },
     {
       "login": "ilirbeqirii",
       "name": "Ilir Beqiri",
       "avatar_url": "https://avatars.githubusercontent.com/u/24731032?v=4",
       "profile": "https://github.com/ilirbeqirii",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "eneajaho",
       "name": "Enea Jahollari",
       "avatar_url": "https://avatars.githubusercontent.com/u/25394362?v=4",
       "profile": "https://eneajaho.me",
-      "contributions": [
-        "code",
-        "bug"
-      ]
+      "contributions": ["code", "bug"]
     },
     {
       "login": "ahmedhmf",
       "name": "Ahmed Moustafa",
       "avatar_url": "https://avatars.githubusercontent.com/u/43710157?v=4",
       "profile": "https://ahmed-moustafa.de/",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "rainerhahnekamp",
       "name": "Rainer Hahnekamp",
       "avatar_url": "https://avatars.githubusercontent.com/u/5721205?v=4",
       "profile": "https://www.rainerhahnekamp.com",
-      "contributions": [
-        "code",
-        "doc"
-      ]
+      "contributions": ["code", "doc"]
     },
     {
       "login": "ajitzero",
       "name": "Ajit Panigrahi",
       "avatar_url": "https://avatars.githubusercontent.com/u/19947758?v=4",
       "profile": "https://beta.ajitpanigrahi.com",
-      "contributions": [
-        "code",
-        "bug"
-      ]
+      "contributions": ["code", "bug"]
     },
     {
       "login": "nekomamoushi",
       "name": "nekomamoushi",
       "avatar_url": "https://avatars.githubusercontent.com/u/46743117?v=4",
       "profile": "https://github.com/nekomamoushi",
-      "contributions": [
-        "code",
-        "bug"
-      ]
+      "contributions": ["code", "bug"]
     },
     {
       "login": "d-koppenhagen",
       "name": "Danny Koppenhagen",
       "avatar_url": "https://avatars.githubusercontent.com/u/4279702?v=4",
       "profile": "https://k9n.dev",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     }
   ]
 }

--- a/angular-hub/index.html
+++ b/angular-hub/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/angular-hub/src/app/app.component.ts
+++ b/angular-hub/src/app/app.component.ts
@@ -23,14 +23,14 @@ export class AppComponent {
 
   constructor(
     private readonly iconRegistry: MatIconRegistry,
-    private readonly sanitizer: DomSanitizer
+    private readonly sanitizer: DomSanitizer,
   ) {
     this.icons.forEach((icon) => {
       this.iconRegistry.addSvgIcon(
         icon,
         this.sanitizer.bypassSecurityTrustResourceUrl(
-          `assets/icons/${icon}.svg`
-        )
+          `assets/icons/${icon}.svg`,
+        ),
       );
     });
   }

--- a/angular-hub/src/app/components/cards/call-for-paper-card.component.ts
+++ b/angular-hub/src/app/components/cards/call-for-paper-card.component.ts
@@ -1,12 +1,12 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { CallForPapers } from '../../models/call-for-papers.model';
-import { DatePipe, NgIf, NgOptimizedImage } from '@angular/common';
+import { DatePipe, NgOptimizedImage } from '@angular/common';
 
 @Component({
   selector: 'app-cfp-card',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgOptimizedImage, DatePipe, NgIf],
+  imports: [NgOptimizedImage, DatePipe],
   template: `
     <article class="flex w-full items-center gap-4">
       <img
@@ -17,12 +17,11 @@ import { DatePipe, NgIf, NgOptimizedImage } from '@angular/common';
         alt=""
       />
       <div class="text-start">
-        <span
-          *ngIf="cfp.deadline"
-          class="font-bold text-primary"
-          itemprop="date"
-          >Until {{ cfp.deadline | date }}</span
-        >
+        @if (cfp.deadline) {
+          <span class="font-bold text-primary" itemprop="date"
+            >Until {{ cfp.deadline | date }}</span
+          >
+        }
         <h3 [attr.id]="cfp.title" class="text-xl font-bold" itemprop="title">
           {{ cfp.title }}
         </h3>

--- a/angular-hub/src/app/components/cards/call-for-paper-lite-card.component.ts
+++ b/angular-hub/src/app/components/cards/call-for-paper-lite-card.component.ts
@@ -1,12 +1,12 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { CallForPapers } from '../../models/call-for-papers.model';
-import { DatePipe, NgIf, NgOptimizedImage } from '@angular/common';
+import { DatePipe, NgOptimizedImage } from '@angular/common';
 
 @Component({
   selector: 'app-cfp-lite-card',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgOptimizedImage, DatePipe, NgIf],
+  imports: [NgOptimizedImage, DatePipe],
   template: `
     <article class="flex flex-col w-full">
       <div class="flex flex-wrap items-center">
@@ -21,9 +21,11 @@ import { DatePipe, NgIf, NgOptimizedImage } from '@angular/common';
           cfp.location
         }}</span>
       </div>
-      <span *ngIf="cfp.deadline" class="font-bold text-primary" itemprop="date"
-        >Until {{ cfp.deadline | date }}</span
-      >
+      @if (cfp.deadline) {
+        <span class="font-bold text-primary" itemprop="date"
+          >Until {{ cfp.deadline | date }}</span
+        >
+      }
     </article>
   `,
   styles: [

--- a/angular-hub/src/app/components/cards/event-card.component.ts
+++ b/angular-hub/src/app/components/cards/event-card.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { Event } from '../../models/event.model';
-import { DatePipe, NgForOf, NgIf, NgOptimizedImage } from '@angular/common';
+import { DatePipe, NgOptimizedImage } from '@angular/common';
 import { EventTagComponent } from '../event-tag.component';
 
 @Component({
@@ -30,14 +30,16 @@ import { EventTagComponent } from '../event-tag.component';
           <li class="inline">
             <app-event-tag [name]="event.language" />
           </li>
-          <li *ngFor="let tag of event.tags" class="inline">
-            <app-event-tag [name]="tag" />
-          </li>
+          @for (tag of event.tags; track tag) {
+            <li class="inline">
+              <app-event-tag [name]="tag" />
+            </li>
+          }
         </ul>
       </div>
     </article>
   `,
-  imports: [DatePipe, NgOptimizedImage, NgIf, NgForOf, EventTagComponent],
+  imports: [DatePipe, NgOptimizedImage, EventTagComponent],
   styles: [
     `
       :host {

--- a/angular-hub/src/app/components/cards/event-lite-card.component.ts
+++ b/angular-hub/src/app/components/cards/event-lite-card.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { Event } from '../../models/event.model';
-import { DatePipe, NgForOf, NgIf, NgOptimizedImage } from '@angular/common';
+import { DatePipe, NgOptimizedImage } from '@angular/common';
 import { EventTagComponent } from '../event-tag.component';
 
 @Component({
@@ -25,19 +25,20 @@ import { EventTagComponent } from '../event-tag.component';
         <span class="font-bold text-primary mr-4" itemprop="date">{{
           event.date | date
         }}</span>
-
         <ul class="flex flex-wrap gap-2">
           <li class="inline">
             <app-event-tag [name]="event.language" />
           </li>
-          <li *ngFor="let tag of event.tags" class="inline">
-            <app-event-tag [name]="tag" />
-          </li>
+          @for (tag of event.tags; track tag) {
+            <li class="inline">
+              <app-event-tag [name]="tag" />
+            </li>
+          }
         </ul>
       </div>
     </article>
   `,
-  imports: [DatePipe, NgOptimizedImage, NgIf, NgForOf, EventTagComponent],
+  imports: [DatePipe, NgOptimizedImage, EventTagComponent],
   styles: [
     `
       :host {

--- a/angular-hub/src/app/components/cards/podcast-card.component.ts
+++ b/angular-hub/src/app/components/cards/podcast-card.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
-import { NgForOf, NgIf, NgOptimizedImage } from '@angular/common';
+import { NgOptimizedImage } from '@angular/common';
 import { EventTagComponent } from '../event-tag.component';
 import { Podcast } from '../../models/podcast.model';
 
@@ -28,7 +28,7 @@ import { Podcast } from '../../models/podcast.model';
       </div>
     </article>
   `,
-  imports: [NgOptimizedImage, NgIf, NgForOf, EventTagComponent],
+  imports: [NgOptimizedImage, EventTagComponent],
   styles: [
     `
       :host {

--- a/angular-hub/src/app/components/cards/podcast-lite-card.component.ts
+++ b/angular-hub/src/app/components/cards/podcast-lite-card.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
-import { NgForOf, NgIf, NgOptimizedImage } from '@angular/common';
+import { NgOptimizedImage } from '@angular/common';
 import { EventTagComponent } from '../event-tag.component';
 import { Podcast } from '../../models/podcast.model';
 
@@ -15,7 +15,7 @@ import { Podcast } from '../../models/podcast.model';
       <app-event-tag [name]="podcast.language" />
     </article>
   `,
-  imports: [NgOptimizedImage, NgIf, NgForOf, EventTagComponent],
+  imports: [NgOptimizedImage, EventTagComponent],
   styles: [
     `
       :host {

--- a/angular-hub/src/app/components/navigation/navigation.component.html
+++ b/angular-hub/src/app/components/navigation/navigation.component.html
@@ -50,10 +50,11 @@
         >
         <a mat-list-item routerLink="/talks" routerLinkActive="active">Talks</a>
       </mat-nav-list>
-      <app-footer *ngIf="!isHandset" [isHandset]="false"></app-footer>
+      @if (!isHandset) {
+        <app-footer [isHandset]="false"></app-footer>
+      }
     </div>
   </mat-sidenav>
-
   <mat-sidenav
     #settings
     class="min-w-[300px]"
@@ -65,15 +66,16 @@
   >
     <mat-toolbar class="flex justify-between items-center !bg-inherit">
       <span class="font-bold text-lg">Settings</span>
-      <button
-        mat-icon-button
-        type="button"
-        (click)="settings.close()"
-        aria-label="Close settings panel"
-        *ngIf="isHandset"
-      >
-        <mat-icon svgIcon="close"></mat-icon>
-      </button>
+      @if (isHandset) {
+        <button
+          mat-icon-button
+          type="button"
+          (click)="settings.close()"
+          aria-label="Close settings panel"
+        >
+          <mat-icon svgIcon="close"></mat-icon>
+        </button>
+      }
     </mat-toolbar>
     <section class="p-2">
       <fieldset>
@@ -135,7 +137,6 @@
       </fieldset>
     </section>
   </mat-sidenav>
-
   <mat-sidenav-content class="!flex flex-col p-4">
     <header
       class="flex justify-between"
@@ -144,24 +145,21 @@
         'items-start': !isHandset
       }"
     >
-      <button
-        *ngIf="isHandset"
-        type="button"
-        aria-label="Open navigation menu"
-        mat-icon-button
-        (click)="navigation.toggle()"
-      >
-        <mat-icon svgIcon="menu"></mat-icon>
-      </button>
-
-      <span *ngIf="isHandset" class="title text-2xl">ANGULAR HUB</span>
-      <h1
-        *ngIf="!isHandset"
-        class="text-3xl text-start sm:text-5xl font-bold mt-2 mb-6"
-      >
-        {{ headerTitle() }}
-      </h1>
-
+      @if (isHandset) {
+        <button
+          type="button"
+          aria-label="Open navigation menu"
+          mat-icon-button
+          (click)="navigation.toggle()"
+        >
+          <mat-icon svgIcon="menu"></mat-icon>
+        </button>
+        <span class="title text-2xl">ANGULAR HUB</span>
+      } @else {
+        <h1 class="text-3xl text-start sm:text-5xl font-bold mt-2 mb-6">
+          {{ headerTitle() }}
+        </h1>
+      }
       <div>
         <button
           type="button"
@@ -171,7 +169,6 @@
         >
           <mat-icon svgIcon="search"></mat-icon>
         </button>
-
         <button
           type="button"
           aria-label="Open settings menu"
@@ -183,14 +180,15 @@
       </div>
     </header>
     <main class="flex-1">
-      <h1
-        *ngIf="isHandset && headerTitle()"
-        class="text-3xl text-start sm:text-5xl font-bold mt-2 mb-6"
-      >
-        {{ headerTitle() }}
-      </h1>
+      @if (isHandset && headerTitle()) {
+        <h1 class="text-3xl text-start sm:text-5xl font-bold mt-2 mb-6">
+          {{ headerTitle() }}
+        </h1>
+      }
       <router-outlet></router-outlet>
     </main>
-    <app-footer *ngIf="isHandset"></app-footer>
+    @if (isHandset) {
+      <app-footer></app-footer>
+    }
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/angular-hub/src/app/components/navigation/navigation.component.ts
+++ b/angular-hub/src/app/components/navigation/navigation.component.ts
@@ -76,7 +76,7 @@ export class NavigationComponent implements OnInit {
     .observe(Breakpoints.Handset)
     .pipe(
       map((result) => result.matches),
-      shareReplay()
+      shareReplay(),
     );
 
   @ViewChild('navigation') navigation!: MatDrawer;
@@ -116,7 +116,7 @@ export class NavigationComponent implements OnInit {
     this.#router.events
       .pipe(
         withLatestFrom(this.isHandset$),
-        filter(([a, b]) => b && a instanceof NavigationEnd)
+        filter(([a, b]) => b && a instanceof NavigationEnd),
       )
       .subscribe(() => this.navigation.close());
   }

--- a/angular-hub/src/app/components/navigation/navigation.component.ts
+++ b/angular-hub/src/app/components/navigation/navigation.component.ts
@@ -17,7 +17,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatDrawer, MatSidenavModule } from '@angular/material/sidenav';
-import { isPlatformBrowser, NgClass, NgIf } from '@angular/common';
+import { isPlatformBrowser, NgClass } from '@angular/common';
 import { MatListModule } from '@angular/material/list';
 import {
   IsActiveMatchOptions,
@@ -46,7 +46,6 @@ import { RxLet } from '@rx-angular/template/let';
     MatToolbarModule,
     MatSidenavModule,
     MatListModule,
-    NgIf,
     RouterLink,
     RouterLinkActive,
     FooterComponent,

--- a/angular-hub/src/app/components/search-modal.component.ts
+++ b/angular-hub/src/app/components/search-modal.component.ts
@@ -145,25 +145,25 @@ export class SearchModalComponent {
   searchControl = new FormControl('', { nonNullable: true });
 
   events = injectContentFiles<Event>(({ filename }) =>
-    filename.startsWith('/src/content/events/')
+    filename.startsWith('/src/content/events/'),
   ).map((event) => event.attributes);
 
   callForPapers = injectContentFiles<CallForPapers>(({ filename }) =>
-    filename.startsWith('/src/content/cfp/')
+    filename.startsWith('/src/content/cfp/'),
   ).map((cfp) => cfp.attributes);
 
   communities = injectContentFiles<Community>(({ filename }) =>
-    filename.startsWith('/src/content/communities/')
+    filename.startsWith('/src/content/communities/'),
   ).map((community) => community.attributes);
 
   podcasts = injectContentFiles<Podcast>(({ filename }) =>
-    filename.startsWith('/src/content/podcasts/')
+    filename.startsWith('/src/content/podcasts/'),
   ).map((podcast) => podcast.attributes);
 
   results$: Observable<SearchResults> = this.searchControl.valueChanges.pipe(
     map((searchTerm: string) => this.filter(searchTerm)),
     startWith(this.setDefaultResults()),
-    shareReplay()
+    shareReplay(),
   );
 
   filter(searchTerm: string): SearchResults {

--- a/angular-hub/src/app/components/search-modal.component.ts
+++ b/angular-hub/src/app/components/search-modal.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { injectContentFiles } from '@analogjs/content';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { AsyncPipe, NgForOf, NgIf } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { Podcast } from '../models/podcast.model';
 import { Event } from '../models/event.model';
 import { CallForPapers } from '../models/call-for-papers.model';
@@ -30,96 +30,98 @@ type SearchResults = {
 @Component({
   selector: 'app-search-modal',
   template: `
-    <mat-dialog-content class="!pt-0" *ngIf="results$ | async as results">
-      <mat-form-field
-        class="sticky w-full z-10 search-field bg-[#424242] pt-5"
-        appearance="outline"
-        subscriptSizing="dynamic"
-      >
-        <mat-icon matPrefix svgIcon="search"></mat-icon>
-        <input
-          [formControl]="searchControl"
-          matInput
-          type="text"
-          placeholder="Search"
-          aria-label="Search activities across the whole application"
-        />
-        <button
-          *ngIf="searchControl.value"
-          type="button"
-          mat-icon-button
-          matSuffix
-          (click)="reset()"
+    @if (results$ | async; as results) {
+      <mat-dialog-content class="!pt-0">
+        <mat-form-field
+          class="sticky w-full z-10 search-field bg-[#424242] pt-5"
+          appearance="outline"
+          subscriptSizing="dynamic"
         >
-          <mat-icon svgIcon="cancel"></mat-icon>
-        </button>
-      </mat-form-field>
-      <ng-container *ngIf="results.events.length">
-        <div class="mt-2">Events</div>
-        <mat-nav-list>
-          <a
-            mat-list-item
-            *ngFor="let event of results.events"
-            [attr.aria-labelledby]="event.title"
-            [href]="event.url"
-            target="_blank"
-          >
-            <app-event-lite-card [event]="event"></app-event-lite-card>
-          </a>
-        </mat-nav-list>
-      </ng-container>
-      <ng-container *ngIf="results.cfp.length">
-        <div class="mt-2">Call for papers</div>
-        <mat-nav-list>
-          <a
-            mat-list-item
-            *ngFor="let cfp of results.cfp"
-            [attr.aria-labelledby]="cfp.title"
-            [href]="cfp.url"
-            target="_blank"
-          >
-            <app-cfp-lite-card [cfp]="cfp"></app-cfp-lite-card>
-          </a>
-        </mat-nav-list>
-      </ng-container>
-      <ng-container *ngIf="results.communities.length">
-        <div class="mt-2">Communities</div>
-        <mat-nav-list>
-          <a
-            mat-list-item
-            *ngFor="let community of results.communities"
-            [attr.aria-labelledby]="community.title"
-            [href]="community.url"
-            target="_blank"
-          >
-            <app-community-lite-card
-              [community]="community"
-            ></app-community-lite-card>
-          </a>
-        </mat-nav-list>
-      </ng-container>
-      <ng-container *ngIf="results.podcasts.length">
-        <div class="mt-2">Podcasts</div>
-        <mat-nav-list>
-          <a
-            mat-list-item
-            *ngFor="let podcast of results.podcasts"
-            [attr.aria-labelledby]="podcast.title"
-            [href]="podcast.url"
-            target="_blank"
-          >
-            <app-podcast-lite-card [podcast]="podcast"></app-podcast-lite-card>
-          </a>
-        </mat-nav-list>
-      </ng-container>
-    </mat-dialog-content>
+          <mat-icon matPrefix svgIcon="search"></mat-icon>
+          <input
+            [formControl]="searchControl"
+            matInput
+            type="text"
+            placeholder="Search"
+            aria-label="Search activities across the whole application"
+          />
+          @if (searchControl.value) {
+            <button type="button" mat-icon-button matSuffix (click)="reset()">
+              <mat-icon svgIcon="cancel"></mat-icon>
+            </button>
+          }
+        </mat-form-field>
+        @if (results.events.length) {
+          <div class="mt-2">Events</div>
+          <mat-nav-list>
+            @for (event of results.events; track event.title) {
+              <a
+                mat-list-item
+                [attr.aria-labelledby]="event.title"
+                [href]="event.url"
+                target="_blank"
+              >
+                <app-event-lite-card [event]="event"></app-event-lite-card>
+              </a>
+            }
+          </mat-nav-list>
+        }
+        @if (results.cfp.length) {
+          <div class="mt-2">Call for papers</div>
+          <mat-nav-list>
+            @for (cfp of results.cfp; track cfp.title) {
+              <a
+                mat-list-item
+                [attr.aria-labelledby]="cfp.title"
+                [href]="cfp.url"
+                target="_blank"
+              >
+                <app-cfp-lite-card [cfp]="cfp"></app-cfp-lite-card>
+              </a>
+            }
+          </mat-nav-list>
+        }
+        @if (results.communities.length) {
+          <div class="mt-2">Communities</div>
+          <mat-nav-list>
+            @for (community of results.communities; track community.title) {
+              <a
+                mat-list-item
+                [attr.aria-labelledby]="community.title"
+                [href]="community.url"
+                target="_blank"
+              >
+                <app-community-lite-card
+                  [community]="community"
+                ></app-community-lite-card>
+              </a>
+            }
+          </mat-nav-list>
+        }
+        @if (results.podcasts.length) {
+          <div class="mt-2">Podcasts</div>
+          <mat-nav-list>
+            @for (podcast of results.podcasts; track podcast.title) {
+              <a
+                mat-list-item
+                [attr.aria-labelledby]="podcast.title"
+                [href]="podcast.url"
+                target="_blank"
+              >
+                <app-podcast-lite-card
+                  [podcast]="podcast"
+                ></app-podcast-lite-card>
+              </a>
+            }
+          </mat-nav-list>
+        }
+      </mat-dialog-content>
+    }
   `,
   standalone: true,
   imports: [
     MatFormFieldModule,
     MatInputModule,
-    NgForOf,
-    NgIf,
     AsyncPipe,
     MatListModule,
     MatIconModule,

--- a/angular-hub/src/app/pages/cfp/index.page.ts
+++ b/angular-hub/src/app/pages/cfp/index.page.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { EventCardComponent } from '../../components/cards/event-card.component';
 import { ContentFile, injectContentFiles } from '@analogjs/content';
-import { AsyncPipe, NgForOf } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import {
   ActivatedRoute,
   Router,
@@ -35,7 +35,6 @@ export const routeMeta: RouteMeta = {
   selector: 'app-cfps',
   standalone: true,
   imports: [
-    NgForOf,
     RouterLink,
     CfpCardComponent,
     SearchBarComponent,
@@ -87,15 +86,16 @@ export const routeMeta: RouteMeta = {
       </ul>
     </nav>
     <mat-nav-list>
-      <a
-        mat-list-item
-        *ngFor="let cfp of cfps$ | async; trackBy: trackbyFn"
-        [attr.aria-labelledby]="cfp.attributes.title"
-        [href]="cfp.attributes.url"
-        target="_blank"
-      >
-        <app-cfp-card [cfp]="cfp.attributes"></app-cfp-card>
-      </a>
+      @for (cfp of cfps$ | async; track cfp.attributes.title) {
+        <a
+          mat-list-item
+          [attr.aria-labelledby]="cfp.attributes.title"
+          [href]="cfp.attributes.url"
+          target="_blank"
+        >
+          <app-cfp-card [cfp]="cfp.attributes"></app-cfp-card>
+        </a>
+      }
     </mat-nav-list>
   `,
   styles: `
@@ -169,10 +169,5 @@ export default class CallForPapersComponent {
       .includes(searchTerm.toLowerCase());
 
     return isTitleMatching || isLocationMatching;
-  }
-
-  // TODO : to be removed with control flow update
-  trackbyFn(index: number, cfp: ContentFile<CallForPapers>): string {
-    return cfp.attributes.title;
   }
 }

--- a/angular-hub/src/app/pages/cfp/index.page.ts
+++ b/angular-hub/src/app/pages/cfp/index.page.ts
@@ -95,6 +95,8 @@ export const routeMeta: RouteMeta = {
         >
           <app-cfp-card [cfp]="cfp.attributes"></app-cfp-card>
         </a>
+      } @empty {
+        <span>No CFPs found!</span>
       }
     </mat-nav-list>
   `,

--- a/angular-hub/src/app/pages/cfp/index.page.ts
+++ b/angular-hub/src/app/pages/cfp/index.page.ts
@@ -109,31 +109,31 @@ export const routeMeta: RouteMeta = {
 export default class CallForPapersComponent {
   searchControl = new FormControl<string>('', { nonNullable: true });
   cfps = injectContentFiles<CallForPapers>(({ filename }) =>
-    filename.startsWith('/src/content/cfp/')
+    filename.startsWith('/src/content/cfp/'),
   );
 
   cfps$ = this.route.queryParams.pipe(
     tap(({ search = '' }) =>
-      this.searchControl.setValue(search, { emitEvent: false })
+      this.searchControl.setValue(search, { emitEvent: false }),
     ),
     map(({ search: searchTerm = '', state }) => {
       let cfps: ContentFile<CallForPapers>[] = this.cfps;
 
       if (state === 'meetups') {
         cfps = this.cfps.filter(
-          ({ attributes }) => attributes.type === 'meetup'
+          ({ attributes }) => attributes.type === 'meetup',
         );
       }
 
       if (state === 'conferences') {
         cfps = this.cfps.filter(
-          ({ attributes }) => attributes.type === 'conference'
+          ({ attributes }) => attributes.type === 'conference',
         );
       }
       return cfps.filter((cfp) =>
-        this.filterPredicate(cfp.attributes, searchTerm)
+        this.filterPredicate(cfp.attributes, searchTerm),
       );
-    })
+    }),
   );
 
   @Input() set header(header: string) {
@@ -143,7 +143,7 @@ export default class CallForPapersComponent {
   constructor(
     private readonly headerService: HeaderService,
     private readonly route: ActivatedRoute,
-    private readonly router: Router
+    private readonly router: Router,
   ) {
     this.searchControl.valueChanges
       .pipe(debounceTime(300), distinctUntilChanged(), takeUntilDestroyed())

--- a/angular-hub/src/app/pages/communities/index.page.ts
+++ b/angular-hub/src/app/pages/communities/index.page.ts
@@ -104,32 +104,32 @@ export const routeMeta: RouteMeta = {
 export default class EvenementsComponent {
   searchControl = new FormControl<string>('', { nonNullable: true });
   communities = injectContentFiles<Community>(({ filename }) =>
-    filename.startsWith('/src/content/communities/')
+    filename.startsWith('/src/content/communities/'),
   );
 
   communities$ = this.route.queryParams.pipe(
     tap(({ search = '' }) =>
-      this.searchControl.setValue(search, { emitEvent: false })
+      this.searchControl.setValue(search, { emitEvent: false }),
     ),
     map(({ search: searchTerm = '', state }) => {
       let communities: ContentFile<Community>[] = this.communities;
 
       if (state === 'meetups') {
         communities = this.communities.filter(
-          ({ attributes }) => attributes.type === 'meetup'
+          ({ attributes }) => attributes.type === 'meetup',
         );
       }
 
       if (state === 'conferences') {
         communities = this.communities.filter(
-          ({ attributes }) => attributes.type === 'conference'
+          ({ attributes }) => attributes.type === 'conference',
         );
       }
 
       return communities.filter((community) =>
-        this.filterPredicate(community.attributes, searchTerm)
+        this.filterPredicate(community.attributes, searchTerm),
       );
-    })
+    }),
   );
 
   @Input() set header(header: string) {
@@ -139,7 +139,7 @@ export default class EvenementsComponent {
   constructor(
     private readonly headerService: HeaderService,
     private readonly route: ActivatedRoute,
-    private readonly router: Router
+    private readonly router: Router,
   ) {
     this.searchControl.valueChanges
       .pipe(debounceTime(300), distinctUntilChanged(), takeUntilDestroyed())

--- a/angular-hub/src/app/pages/communities/index.page.ts
+++ b/angular-hub/src/app/pages/communities/index.page.ts
@@ -93,6 +93,8 @@ export const routeMeta: RouteMeta = {
             [community]="community.attributes"
           ></app-community-card>
         </a>
+      } @empty {
+        <span>No Communities found!</span>
       }
     </mat-nav-list>
   `,

--- a/angular-hub/src/app/pages/communities/index.page.ts
+++ b/angular-hub/src/app/pages/communities/index.page.ts
@@ -1,6 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { ContentFile, injectContentFiles } from '@analogjs/content';
-import { AsyncPipe, NgForOf } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { Community } from '../../models/community.model';
 import { CommunityCardComponent } from '../../components/cards/community-card.component';
 import {
@@ -34,7 +34,6 @@ export const routeMeta: RouteMeta = {
   selector: 'app-communities',
   standalone: true,
   imports: [
-    NgForOf,
     CommunityCardComponent,
     RouterLink,
     SearchBarComponent,
@@ -80,17 +79,21 @@ export const routeMeta: RouteMeta = {
       </ul>
     </nav>
     <mat-nav-list>
-      <a
-        mat-list-item
-        *ngFor="let community of communities$ | async; trackBy: trackbyFn"
-        [attr.aria-labelledby]="community.attributes.title"
-        [href]="community.attributes.url"
-        target="_blank"
-      >
-        <app-community-card
-          [community]="community.attributes"
-        ></app-community-card>
-      </a>
+      @for (
+        community of communities$ | async;
+        track community.attributes.title
+      ) {
+        <a
+          mat-list-item
+          [attr.aria-labelledby]="community.attributes.title"
+          [href]="community.attributes.url"
+          target="_blank"
+        >
+          <app-community-card
+            [community]="community.attributes"
+          ></app-community-card>
+        </a>
+      }
     </mat-nav-list>
   `,
   styles: `
@@ -165,10 +168,5 @@ export default class EvenementsComponent {
       .includes(searchTerm.toLowerCase());
 
     return isTitleMatching || isLocationMatching;
-  }
-
-  // TODO : to be removed with control flow update
-  trackbyFn(index: number, community: ContentFile<Community>): string {
-    return community.attributes.title;
   }
 }

--- a/angular-hub/src/app/pages/discover/index.page.ts
+++ b/angular-hub/src/app/pages/discover/index.page.ts
@@ -63,17 +63,16 @@ export const routeMeta: RouteMeta = {
             >
               <app-event-card [event]="event.attributes"></app-event-card>
             </a>
+          } @empty {
+            <p class="mb-4">There are no more events planned this week!</p>
+            <a
+              class="text-xl font-bold bg-primary px-6 py-2 rounded-lg"
+              routerLink="/events"
+              [queryParams]="{ state: 'upcoming' }"
+              >Discover upcoming events</a
+            >
           }
         </mat-nav-list>
-        @if (!currentWeekEvents.length) {
-          <p class="mb-4">There are no more events planned this week!</p>
-          <a
-            class="text-xl font-bold bg-primary px-6 py-2 rounded-lg"
-            routerLink="/events"
-            [queryParams]="{ state: 'upcoming' }"
-            >Discover upcoming events</a
-          >
-        }
       </section>
       <section>
         <h2 class="text-2xl text-start sm:text-3xl font-bold mt-2 mb-4">
@@ -89,6 +88,8 @@ export const routeMeta: RouteMeta = {
             >
               <app-cfp-card [cfp]="cfp.attributes"></app-cfp-card>
             </a>
+          } @empty {
+            <span>No CFPs at the moment!</span>
           }
         </mat-nav-list>
       </section>

--- a/angular-hub/src/app/pages/discover/index.page.ts
+++ b/angular-hub/src/app/pages/discover/index.page.ts
@@ -118,13 +118,13 @@ export default class DiscoverComponent {
   #headerService = inject(HeaderService);
 
   currentWeekEvents = injectContentFiles<Event>(({ filename }) =>
-    filename.startsWith('/src/content/events/')
+    filename.startsWith('/src/content/events/'),
   )
     .filter((event) => isThisSOWeek(new Date(event.attributes.date)))
     .filter((event) => isFuture(new Date(event.attributes.date)));
 
   activeCallForPapers = injectContentFiles<CallForPapers>(({ filename }) =>
-    filename.startsWith('/src/content/cfp/')
+    filename.startsWith('/src/content/cfp/'),
   ).filter((event) => new Date(event.attributes.deadline) > new Date());
 
   @Input() set header(header: string) {

--- a/angular-hub/src/app/pages/discover/index.page.ts
+++ b/angular-hub/src/app/pages/discover/index.page.ts
@@ -2,7 +2,7 @@ import { Component, inject, Input } from '@angular/core';
 import { HeaderService } from '../../services/header.service';
 import { RouteMeta } from '@analogjs/router';
 import { injectContentFiles } from '@analogjs/content';
-import { NgForOf, NgIf, NgOptimizedImage } from '@angular/common';
+import { NgOptimizedImage } from '@angular/common';
 import { Event } from '../../models/event.model';
 import isThisSOWeek from 'date-fns/isThisISOWeek';
 import { EventCardComponent } from '../../components/cards/event-card.component';
@@ -32,7 +32,6 @@ export const routeMeta: RouteMeta = {
       Explore upcoming events and latest call for papers in the Angular
       community.
     </p>
-
     <a
       class="flex gap-2 items-center bg-white rounded-lg w-fit p-2 mt-8 mb-8 border-primary border-2 dark:border-white"
       href="https://t.co/Ho7xL97EDq"
@@ -55,17 +54,18 @@ export const routeMeta: RouteMeta = {
           Upcoming events this week
         </h2>
         <mat-nav-list>
-          <a
-            mat-list-item
-            *ngFor="let event of currentWeekEvents"
-            [attr.aria-labelledby]="event.attributes.title"
-            [href]="event.attributes.url"
-            target="_blank"
-          >
-            <app-event-card [event]="event.attributes"></app-event-card>
-          </a>
+          @for (event of currentWeekEvents; track event.attributes.title) {
+            <a
+              mat-list-item
+              [attr.aria-labelledby]="event.attributes.title"
+              [href]="event.attributes.url"
+              target="_blank"
+            >
+              <app-event-card [event]="event.attributes"></app-event-card>
+            </a>
+          }
         </mat-nav-list>
-        <ng-container *ngIf="!currentWeekEvents.length">
+        @if (!currentWeekEvents.length) {
           <p class="mb-4">There are no more events planned this week!</p>
           <a
             class="text-xl font-bold bg-primary px-6 py-2 rounded-lg"
@@ -73,34 +73,33 @@ export const routeMeta: RouteMeta = {
             [queryParams]="{ state: 'upcoming' }"
             >Discover upcoming events</a
           >
-        </ng-container>
+        }
       </section>
       <section>
         <h2 class="text-2xl text-start sm:text-3xl font-bold mt-2 mb-4">
           Submit your talks!
         </h2>
         <mat-nav-list>
-          <a
-            mat-list-item
-            *ngFor="let cfp of activeCallForPapers"
-            [attr.aria-labelledby]="cfp.attributes.title"
-            [href]="cfp.attributes.url"
-            target="_blank"
-          >
-            <app-cfp-card [cfp]="cfp.attributes"></app-cfp-card>
-          </a>
+          @for (cfp of activeCallForPapers; track cfp.attributes.title) {
+            <a
+              mat-list-item
+              [attr.aria-labelledby]="cfp.attributes.title"
+              [href]="cfp.attributes.url"
+              target="_blank"
+            >
+              <app-cfp-card [cfp]="cfp.attributes"></app-cfp-card>
+            </a>
+          }
         </mat-nav-list>
       </section>
     </div>
   `,
   standalone: true,
   imports: [
-    NgForOf,
     EventCardComponent,
     MatListModule,
     CfpCardComponent,
     NgOptimizedImage,
-    NgIf,
     RouterLink,
   ],
   styles: `

--- a/angular-hub/src/app/pages/events/index.page.ts
+++ b/angular-hub/src/app/pages/events/index.page.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { EventCardComponent } from '../../components/cards/event-card.component';
-import { ContentFile, injectContentFiles } from '@analogjs/content';
-import { AsyncPipe, NgForOf } from '@angular/common';
+import { injectContentFiles } from '@analogjs/content';
+import { AsyncPipe } from '@angular/common';
 import { Event } from '../../models/event.model';
 import {
   ActivatedRoute,
@@ -34,7 +34,6 @@ export const routeMeta: RouteMeta = {
   selector: 'app-evenements',
   standalone: true,
   imports: [
-    NgForOf,
     EventCardComponent,
     RouterLink,
     AsyncPipe,
@@ -69,17 +68,17 @@ export const routeMeta: RouteMeta = {
         </li>
       </ul>
     </nav>
-
     <mat-nav-list>
-      <a
-        mat-list-item
-        *ngFor="let event of events$ | async; trackBy: trackbyFn"
-        [attr.aria-labelledby]="event.attributes.title"
-        [href]="event.attributes.url"
-        target="_blank"
-      >
-        <app-event-card [event]="event.attributes"></app-event-card>
-      </a>
+      @for (event of events$ | async; track event.attributes.title) {
+        <a
+          mat-list-item
+          [attr.aria-labelledby]="event.attributes.title"
+          [href]="event.attributes.url"
+          target="_blank"
+        >
+          <app-event-card [event]="event.attributes"></app-event-card>
+        </a>
+      }
     </mat-nav-list>
   `,
   styles: `
@@ -167,11 +166,6 @@ export default class EvenementsComponent {
       .includes(searchTerm.toLowerCase());
 
     return isTitleMatching || isLocationMatching;
-  }
-
-  // TODO : to be removed with control flow update
-  trackbyFn(index: number, event: ContentFile<Event>): string {
-    return event.attributes.title;
   }
 
   today(): Date {

--- a/angular-hub/src/app/pages/events/index.page.ts
+++ b/angular-hub/src/app/pages/events/index.page.ts
@@ -94,18 +94,18 @@ export default class EvenementsComponent {
   searchControl = new FormControl<string>('', { nonNullable: true });
 
   evenements = injectContentFiles<Event>(({ filename }) =>
-    filename.startsWith('/src/content/events/')
+    filename.startsWith('/src/content/events/'),
   );
   pastEvents = this.evenements.filter(
-    (event) => new Date(event.attributes.date) < this.today()
+    (event) => new Date(event.attributes.date) < this.today(),
   );
   upcomingEvents = this.evenements.filter(
-    (event) => new Date(event.attributes.date) >= this.today()
+    (event) => new Date(event.attributes.date) >= this.today(),
   );
 
   events$ = this.route.queryParams.pipe(
     tap(({ search = '' }) =>
-      this.searchControl.setValue(search, { emitEvent: false })
+      this.searchControl.setValue(search, { emitEvent: false }),
     ),
     map(({ search: searchTerm = '', state }) => {
       if (state === 'past') {
@@ -131,7 +131,7 @@ export default class EvenementsComponent {
             ? a.attributes.title.localeCompare(b.attributes.title)
             : dayDiff;
         });
-    })
+    }),
   );
 
   @Input() set header(header: string) {
@@ -141,7 +141,7 @@ export default class EvenementsComponent {
   constructor(
     private headerService: HeaderService,
     private readonly route: ActivatedRoute,
-    private readonly router: Router
+    private readonly router: Router,
   ) {
     this.searchControl.valueChanges
       .pipe(debounceTime(300), distinctUntilChanged(), takeUntilDestroyed())

--- a/angular-hub/src/app/pages/events/index.page.ts
+++ b/angular-hub/src/app/pages/events/index.page.ts
@@ -78,6 +78,8 @@ export const routeMeta: RouteMeta = {
         >
           <app-event-card [event]="event.attributes"></app-event-card>
         </a>
+      } @empty {
+        <span>No Events found!</span>
       }
     </mat-nav-list>
   `,

--- a/angular-hub/src/app/pages/podcasts/index.page.ts
+++ b/angular-hub/src/app/pages/podcasts/index.page.ts
@@ -67,18 +67,18 @@ export const routeMeta: RouteMeta = {
 export default class PodcastsComponent {
   searchControl = new FormControl<string>('', { nonNullable: true });
   podcasts = injectContentFiles<Podcast>(({ filename }) =>
-    filename.startsWith('/src/content/podcasts/')
+    filename.startsWith('/src/content/podcasts/'),
   );
 
   podcasts$ = this.route.queryParams.pipe(
     tap(({ search = '' }) =>
-      this.searchControl.setValue(search, { emitEvent: false })
+      this.searchControl.setValue(search, { emitEvent: false }),
     ),
     map(({ search: searchTerm = '' }) => {
       return this.podcasts.filter((podcast) =>
-        this.filterPredicate(podcast.attributes, searchTerm)
+        this.filterPredicate(podcast.attributes, searchTerm),
       );
-    })
+    }),
   );
 
   @Input() set header(header: string) {
@@ -88,7 +88,7 @@ export default class PodcastsComponent {
   constructor(
     private headerService: HeaderService,
     private router: Router,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
   ) {
     this.searchControl.valueChanges
       .pipe(debounceTime(300), distinctUntilChanged(), takeUntilDestroyed())

--- a/angular-hub/src/app/pages/podcasts/index.page.ts
+++ b/angular-hub/src/app/pages/podcasts/index.page.ts
@@ -53,6 +53,8 @@ export const routeMeta: RouteMeta = {
         >
           <app-podcast-card [podcast]="podcast.attributes"></app-podcast-card>
         </a>
+      } @empty {
+        <span>No Podcasts found!</span>
       }
     </mat-nav-list>
   `,

--- a/angular-hub/src/app/pages/podcasts/index.page.ts
+++ b/angular-hub/src/app/pages/podcasts/index.page.ts
@@ -1,6 +1,6 @@
 import { Component, Input } from '@angular/core';
-import { ContentFile, injectContentFiles } from '@analogjs/content';
-import { AsyncPipe, NgForOf } from '@angular/common';
+import { injectContentFiles } from '@analogjs/content';
+import { AsyncPipe } from '@angular/common';
 import {
   ActivatedRoute,
   Router,
@@ -33,7 +33,6 @@ export const routeMeta: RouteMeta = {
   selector: 'app-podcasts',
   standalone: true,
   imports: [
-    NgForOf,
     RouterLink,
     SearchBarComponent,
     RouterLinkActive,
@@ -45,15 +44,16 @@ export const routeMeta: RouteMeta = {
   template: `
     <app-search-bar [formControl]="searchControl"></app-search-bar>
     <mat-nav-list>
-      <a
-        mat-list-item
-        *ngFor="let podcast of podcasts$ | async; trackBy: trackbyFn"
-        [attr.aria-labelledby]="podcast.attributes.title"
-        [href]="podcast.attributes.url"
-        target="_blank"
-      >
-        <app-podcast-card [podcast]="podcast.attributes"></app-podcast-card>
-      </a>
+      @for (podcast of podcasts$ | async; track podcast.attributes.title) {
+        <a
+          mat-list-item
+          [attr.aria-labelledby]="podcast.attributes.title"
+          [href]="podcast.attributes.url"
+          target="_blank"
+        >
+          <app-podcast-card [podcast]="podcast.attributes"></app-podcast-card>
+        </a>
+      }
     </mat-nav-list>
   `,
   styles: `
@@ -107,10 +107,5 @@ export default class PodcastsComponent {
     }
 
     return podcast.title.toLowerCase().includes(searchTerm.toLowerCase());
-  }
-
-  // TODO : to be removed with control flow update
-  trackbyFn(index: number, podcast: ContentFile<Podcast>): string {
-    return podcast.attributes.title;
   }
 }

--- a/angular-hub/src/app/pages/talks/index.page.ts
+++ b/angular-hub/src/app/pages/talks/index.page.ts
@@ -1,5 +1,5 @@
 import { Component, inject, Input } from '@angular/core';
-import { NgForOf, NgOptimizedImage } from '@angular/common';
+import { NgOptimizedImage } from '@angular/common';
 import { CommunityCardComponent } from '../../components/cards/community-card.component';
 import { RouterLink } from '@angular/router';
 import { TalkCardComponent } from '../../components/cards/talk-card.component';
@@ -23,7 +23,6 @@ export const routeMeta: RouteMeta = {
   selector: 'app-talks',
   standalone: true,
   imports: [
-    NgForOf,
     NgOptimizedImage,
     CommunityCardComponent,
     RouterLink,

--- a/angular-hub/src/main.ts
+++ b/angular-hub/src/main.ts
@@ -5,5 +5,5 @@ import { AppComponent } from './app/app.component';
 import { appConfig } from './app/app.config';
 
 bootstrapApplication(AppComponent, appConfig).catch((err) =>
-  console.error(err)
+  console.error(err),
 );

--- a/angular-hub/src/test-setup.ts
+++ b/angular-hub/src/test-setup.ts
@@ -8,5 +8,5 @@ import { getTestBed } from '@angular/core/testing';
 
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "lint-staged": "^15.1.0",
         "nx": "17.1.3",
         "postcss": "^8.4.5",
-        "prettier": "^2.6.2",
+        "prettier": "3.1.1",
         "tailwindcss": "^3.0.2",
         "typescript": "~5.2.2",
         "vite": "^4.4.8",
@@ -20701,15 +20701,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+      "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "lint-staged": "^15.1.0",
     "nx": "17.1.3",
     "postcss": "^8.4.5",
-    "prettier": "^2.6.2",
+    "prettier": "3.1.1",
     "tailwindcss": "^3.0.2",
     "typescript": "~5.2.2",
     "vite": "^4.4.8",


### PR DESCRIPTION
<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->

<!-- Are you adding a conference event? Mind listing it on https://github.com/scraly/developers-conferences-agenda too for a broader audience! -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

We were using *ngIf/*ngFor instead of the new control flow syntax.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #95

## What is the new behavior?
- Migrated to the new control flow syntax.
- Removed all existing trackBy functions manually and updated `@for` blocks with the inline `track` way.
- Added `track` conditions in some places where it was obvious. e.g., `event.attributes.title` was used in the Agenda page but not in the Discover page, so I updated the condition there as well.
- I added `@empty` blocks for all `@for` blocks except in the search modal (not relevant there, IMO). For Discover page, this means I moved the existing code into an empty block and for other pages, I have added "No X found!" message. We can style this as we like later.
- Updated Prettier to v3.1.1 to support this new syntax. Support was added in v3.1.0, but v3.1.1 was published recently (less than 12 hours ago).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
