### PR TITLE
fix: change url path in openapi.yml

### DIFF
--- a/angular-hub/src/public/assets/swagger/openapi.yml
+++ b/angular-hub/src/public/assets/swagger/openapi.yml
@@ -10,7 +10,7 @@ tags:
   - name: Communities
   - name: Podcasts
 servers:
-  - url: https://angular-hub.com/api/v1
+  - url: https://angular-hub.com/api/v1/swagger
 paths:
   /communities:
     get:


### PR DESCRIPTION
<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->

<!-- Are you adding a conference event? Mind listing it on https://github.com/scraly/developers-conferences-agenda too for a broader audience! -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #304   

## What is the new behavior?

The swagger link should work.  

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This might not be a correct fix.  The problem may be with the link href.  The link worked the first time I changed the yml file and then it started to fail again.  Typing `api/v1/swagger` in the URL works and you should be able to navigate.  But clicking the button doesn't work.   Now, I think a swagger route might need to be added to yml file instead.  The app has a `noMatchError`.   

closes #304 