### PR TITLE
fix: add selectOtherMonths to p-calendar

### DIFF
--- a/angular-hub/src/app/pages/index.page.ts
+++ b/angular-hub/src/app/pages/index.page.ts
@@ -149,6 +149,7 @@ export const routeMeta: RouteMeta = {
         (ngModelChange)="date.set($event)"
         [inline]="true"
         [showWeek]="true"
+        [selectOtherMonths]="true"
       >
         <ng-template pTemplate="date" let-date>
           <span [class.activeDate]="hasActiveEvent(date)">

--- a/angular-hub/src/styles.scss
+++ b/angular-hub/src/styles.scss
@@ -68,6 +68,10 @@ body {
   box-shadow: 0 0 5px 5px #00b8e6;
 }
 
+.p-datepicker-other-month {
+  color: grey;
+}
+
 @media (prefers-reduced-motion) {
   ::view-transition-group(*),
   ::view-transition-old(*),


### PR DESCRIPTION
<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->

<!-- Are you adding a conference event? Mind listing it on https://github.com/scraly/developers-conferences-agenda too for a broader audience! -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

You cannot select events in the next month of the calendar.  

Issue Number: #337 

## What is the new behavior?

I added `selectOtherMonths` to `p-calendar` and now events that are early in the next months are clickable.  

Closes #337.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I didn't look into testing or anything extra.