### PR TITLE
fix: remove duplicate primeicons import

### DIFF
--- a/angular-hub/src/styles.scss
+++ b/angular-hub/src/styles.scss
@@ -8,7 +8,6 @@
 @import 'tailwindcss/components.css' layer(tw-components);
 @import 'tailwindcss/utilities.css' layer(tw-utilities);
 @import 'tailwindcss/variants.css' layer(tw-variants);
-@import 'primeicons/primeicons';
 
 @font-face {
   font-family: 'Pixelify';


### PR DESCRIPTION
<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->

<!-- Are you adding a conference event? Mind listing it on https://github.com/scraly/developers-conferences-agenda too for a broader audience! -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Duplicate import of primeicons in styles.scss.

Issue Number: N/A

## What is the new behavior?

Same

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
